### PR TITLE
Added () to avoid parentheses warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule Mbcs.Mixfile do
         licenses: ["MIT"],
         links: %{"GitHub" => "https://github.com/woxtu/elixir-mbcs"}
       ],
-      deps: deps ]
+      deps: deps()
+    ]
   end
 
   def application do


### PR DESCRIPTION
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name